### PR TITLE
8091_fhlint_fixes

### DIFF
--- a/application.js
+++ b/application.js
@@ -1,13 +1,20 @@
 var mbaasApi = require('fh-mbaas-api');
 var express = require('express');
 var mbaasExpress = mbaasApi.mbaasExpress();
-var express = require('express');
+var cors = require('cors');
+
 var beacons = require('./lib/beacons.js');
 
-// Securable endpoints: list the endpoints which you want to make securable here
-var securableEndpoints = ['beacons'];
+// list the endpoints which you want to make securable here
+var securableEndpoints;
+// fhlint-begin: securable-endpoints
+securableEndpoints = ['beacons'];
+// fhlint-end
 
 var app = express();
+
+// Enable CORS for all requests
+app.use(cors());
 
 // Note: the order which we add middleware to Express here is important!
 app.use('/sys', mbaasExpress.sys(securableEndpoints));
@@ -16,19 +23,19 @@ app.use('/mbaas', mbaasExpress.mbaas);
 // Note: important that this is added just before your own Routes
 app.use(mbaasExpress.fhmiddleware());
 
+// allow serving of static files from the public directory
+app.use(express.static(__dirname + '/public'));
+
+// fhlint-begin: custom-routes
 app.use('/beacons', require('./lib/beaconRoutes.js')());
 app.use('/cloud/beacons', require('./lib/beaconRoutes.js')());
-
-// You can define custom URL handlers here, like this one:
-app.use('/', function(req, res){
-  res.end('Your Cloud App is Running');
-});
+// fhlint-end
 
 // Important that this is last!
 app.use(mbaasExpress.errorHandler());
 
 var port = process.env.FH_PORT || process.env.VCAP_APP_PORT || 8001;
-var server = app.listen(port, function(){
+app.listen(port, function(){
   console.log("App started at: " + new Date() + " on port: " + port);
 });
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "express": "4.0.0",
-    "fh-mbaas-api" : "~4.3.0",
+    "fh-mbaas-api" : "~4.5.0",
     "request": "2.34.0",
     "body-parser": "~1.0.2",
     "cors": "~2.2.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,1 @@
+Your Node.js code is deployed and running. This file is served statically from public/index.html.


### PR DESCRIPTION
fhlint fixes - update application.js for fhlint, add static file server, include default index.html - #8091
